### PR TITLE
make sure reloading is working on templates

### DIFF
--- a/ace/ace.go
+++ b/ace/ace.go
@@ -48,7 +48,6 @@ func New(directory, extension string) *Engine {
 		extension: extension,
 		layout:    "embed",
 		funcmap:   make(map[string]interface{}),
-		Templates: template.New(directory),
 	}
 	engine.AddFunc(engine.layout, func() error {
 		return fmt.Errorf("content called unexpectedly.")
@@ -65,7 +64,6 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 		extension:  extension,
 		layout:     "embed",
 		funcmap:    make(map[string]interface{}),
-		Templates:  template.New("/"),
 	}
 	engine.AddFunc(engine.layout, func() error {
 		return fmt.Errorf("content called unexpectedly.")
@@ -121,6 +119,8 @@ func (e *Engine) Load() error {
 	// race safe
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
+
+	e.Templates = template.New(e.directory)
 
 	e.Templates.Delims(e.left, e.right)
 	e.Templates.Funcs(e.funcmap)

--- a/ace/ace_test.go
+++ b/ace/ace_test.go
@@ -2,7 +2,9 @@ package ace
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -78,6 +80,38 @@ func Test_FileSystem(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.ace"
+	fileCont := "reloaded"
+	expect := "<reloaded></reloaded>"
+
+	engine := New("./views", ".ace")
+	engine.Reload(true) // Optional. Default: false
+	engine.AddFunc("isAdmin", func(user string) bool {
+		return user == "admin"
+	})
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/amber/amber_test.go
+++ b/amber/amber_test.go
@@ -2,7 +2,9 @@ package amber
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -78,6 +80,38 @@ func Test_FileSystem(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.ace"
+	fileCont := "reloaded"
+	expect := "<reloaded></reloaded>"
+
+	engine := New("./views", ".ace")
+	engine.Reload(true) // Optional. Default: false
+	engine.AddFunc("isAdmin", func(user string) bool {
+		return user == "admin"
+	})
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/django/django.go
+++ b/django/django.go
@@ -47,7 +47,6 @@ func New(directory, extension string) *Engine {
 		extension: extension,
 		layout:    "embed",
 		funcmap:   make(map[string]interface{}),
-		Templates: make(map[string]*pongo2.Template),
 	}
 	return engine
 }
@@ -61,7 +60,6 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 		extension:  extension,
 		layout:     "embed",
 		funcmap:    make(map[string]interface{}),
-		Templates:  make(map[string]*pongo2.Template),
 	}
 	return engine
 }
@@ -115,6 +113,7 @@ func (e *Engine) Load() error {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
+	e.Templates = make(map[string]*pongo2.Template)
 	// Set template settings
 	set := pongo2.NewSet("", pongo2.DefaultLoader)
 	set.Globals = e.funcmap

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -2,7 +2,9 @@ package django
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -80,6 +82,35 @@ func Test_FileSystem(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.django"
+	fileCont := "reloaded"
+	expect := "reloaded"
+
+	engine := New("./views", ".django")
+	engine.Reload(true)
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/handlebars/handlebars_test.go
+++ b/handlebars/handlebars_test.go
@@ -2,7 +2,9 @@ package handlebars
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -74,6 +76,35 @@ func Test_FileSystem(t *testing.T) {
 		"Title": "Hello, World!",
 	}, "layouts/main")
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.hbs"
+	fileCont := "reloaded"
+	expect := "reloaded"
+
+	engine := New("./views", ".hbs")
+	engine.Reload(true)
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/html/html.go
+++ b/html/html.go
@@ -47,7 +47,6 @@ func New(directory, extension string) *Engine {
 		extension: extension,
 		layout:    "embed",
 		funcmap:   make(map[string]interface{}),
-		Templates: template.New(directory),
 	}
 	engine.AddFunc(engine.layout, func() error {
 		return fmt.Errorf("layout called unexpectedly.")
@@ -64,7 +63,6 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 		extension:  extension,
 		layout:     "embed",
 		funcmap:    make(map[string]interface{}),
-		Templates:  template.New("/"),
 	}
 	engine.AddFunc(engine.layout, func() error {
 		return fmt.Errorf("layout called unexpectedly.")
@@ -120,6 +118,8 @@ func (e *Engine) Load() error {
 	// race safe
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
+
+	e.Templates = template.New(e.directory)
 
 	// Set template settings
 	e.Templates.Delims(e.left, e.right)

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -2,7 +2,9 @@ package html
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -114,6 +116,37 @@ func Test_FileSystem(t *testing.T) {
 		"Title": "Hello, World!",
 	}, "layouts/main")
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.html"
+	fileCont := "reloaded"
+	engine := New("./views", ".html")
+	engine.Reload(true) // Optional. Default: false
+	engine.AddFunc("isAdmin", func(user string) bool {
+		return user == "admin"
+	})
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
+	expect := fileCont
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/jet/jet_test.go
+++ b/jet/jet_test.go
@@ -2,7 +2,9 @@ package jet
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -73,6 +75,35 @@ func Test_FileSystem(t *testing.T) {
 		"Title": "Hello, World!",
 	}, "layouts/main")
 	expect := `<!DOCTYPE html><html><head><title>Title</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.jet"
+	fileCont := "reloaded"
+	expect := "reloaded"
+
+	engine := New("./views", ".jet")
+	engine.Reload(false)
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/mustache/mustache_test.go
+++ b/mustache/mustache_test.go
@@ -2,7 +2,9 @@ package mustache
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -76,6 +78,35 @@ func Test_FileSystem(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.mustache"
+	fileCont := "reloaded"
+	expect := "reloaded"
+
+	engine := New("./views", ".mustache")
+	engine.Reload(true)
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/pug/pug_test.go
+++ b/pug/pug_test.go
@@ -2,7 +2,9 @@ package pug
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -71,6 +73,35 @@ func Test_FileSystem(t *testing.T) {
 		"Title": "Hello, World!",
 	}, "layouts/main")
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+func Test_Reload(t *testing.T) {
+	reloadFile := "./views/reload.pug"
+	fileCont := "reloaded"
+	expect := "<reloaded></reloaded>"
+
+	engine := New("./views", ".pug")
+	engine.Reload(true)
+
+	content := []byte(fileCont)
+	err := ioutil.WriteFile(reloadFile, content, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(reloadFile); err != nil {
+			panic(err)
+		}
+	}()
+
+	engine.Load()
+
+	var buf bytes.Buffer
+	engine.Render(&buf, "reload", nil)
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)


### PR DESCRIPTION
fixes #11
Reloading was working on most template engines (whether reload was true or not), but I went ahead and added tests to all of them to ensure it continues to work.

Everything else was an easy fix of just moving the template initialization to the load function so the current templates are just replaced with a new set.

Django, ace, and html were the only ones not reloading.